### PR TITLE
fixed a bug in print method

### DIFF
--- a/wdi.py
+++ b/wdi.py
@@ -64,12 +64,12 @@ class Array:
             return dim
 
     def print(self):
-        if self.__size2:
+        if self.__sizes[1]:
             print('[')
         else:
             print('[', end='\t')
-        for i in range(self.__size1):
-            if self.__size2:
+        for i in range(self.__sizes[0]):
+            if self.__sizes[1]:
                 print(end='\t')
                 self.__print(self[i])
             else:


### PR DESCRIPTION
 there was a bug with 'print' - there were __size1 and __size2 attributes that doesn't exist - changed to existing sizes[0] and sizes[1] respectively